### PR TITLE
Fix bug where readdir stats were being used in addition to read_bytes

### DIFF
--- a/lustreClient.ph
+++ b/lustreClient.ph
@@ -535,7 +535,7 @@ sub lustreClientAnalyze {
     } elsif ($metric =~ /dirty_pages_misses/) {
       $attrId = 'dirty_pages_misses';
       $tot = \$lustreCltDirtyMissTot;
-    } elsif ($metric =~ /read/) {
+    } elsif ($metric =~ /read_bytes/) {
       $attrId = 'read';
       $tot = \$lustreCltReadTot;
 


### PR DESCRIPTION
Fix bug where readdir stats were being used in addition to read_bytes, causing reads to always be around 4GB \* sample interval
