### PR TITLE
Lustre version file moved

### DIFF
--- a/LustreSingleton.pm
+++ b/LustreSingleton.pm
@@ -35,6 +35,17 @@ sub getVersion {
 			my @version = split(" ",$version_line);
 			$this->{_version} = $version[1];	
 		}
+		else {
+			my $version_filename = '/sys/fs/lustre/version';
+			if (-e $version_filename) {
+				if($this->{_debug}){ print "retrieving version\n"; }
+				open(FF,"<$version_filename");
+				my $version_line = <FF>;
+				close(FF);
+				chomp($version_line);
+				$this->{_version} = $version_line;
+			}
+		}
 	}
 	return $this->{_version};
 }


### PR DESCRIPTION
   The Lustre version file has been moved to /sys/fs/lustre/version. I'm not sure
    which version exactly - between 2.9.0 and 2.9.59. From:
    https://www.mail-archive.com/lustre-discuss@lists.lustre.org/msg13693.html